### PR TITLE
Abstract markup. Author info update.

### DIFF
--- a/asdf2017.scrbl
+++ b/asdf2017.scrbl
@@ -10,7 +10,7 @@
           "utils.rkt" "bibliography.scrbl")
 
 @set-top-matter[#:printccs #t #:printacmref #f #:printfolios #f]
-@authorinfo["Robert P. Goldman" "SIFT" "rpgoldman@sift.info"]
+@authorinfo["Robert P. Goldman" "SIFT" "rpgoldman@sift.net"]
 @authorinfo["Elias Pipping" "FU Berlin" "elias.pipping@fu-berlin.de"]
 @authorinfo["François-René Rideau" "TUNES" "fare@tunes.org"]
 @conferenceinfo[#:short-name "ELS 2017"
@@ -45,14 +45,28 @@
 has markedly improved over the years,
 in features as well as robustness and portability.
 We present a few notable improvements since we last reported on it in 2014:
-enhanced mechanisms for single-file delivery of applications;
-a reasonably portable @tt{launch-program} layer for asynchronous subprocesses;
-a correct incremental build in presence of @(ASDF) extensions,
-now with proper phase separation;
-enhancements with configuration for source location.
-These improvements make @(CL) a better platform for
-writing and delivering applications as well as ``scripts''.
-}
+enhanced mechanisms for delivering an application as a single file;
+a @tt{launch-program} feature for managing asynchronous subprocesses;
+the ability to correctly update @(ASDF) extensions in incremental builds, 
+with proper phase separation; and
+enhancements to the configuration process for source location.
+These improvements make @(CL) a better platform not simply for
+writing and delivering applications but also for use in scripting other applications.
+
+@italic{I don't think the abstract here really makes an argument.  We enumerate
+a list of 4 improvements and claim that some subset of these improvements
+provides 2 benefits: 
+(1) general ASDF goodness, and (2) scripting.  But we leave it
+entirely to the reader to guess the connections between improvements and
+benefits.  Another alternative would be to simply strike the discussion of
+scripting (defer to a different paper), since the title is all about delivering
+applications, and doesn't tell the reader we are concerned with scripting.
+Also, I think we need to do one of two things: either (1) agree that scripting
+is like pornography -- we don't have a definition, but we know it when we see it
+-- and not put in scare quotes every time we talk about scripting; or (2) decide
+that the notion of scripting is problematic, and provide our attempt at a
+definition.  Right now it seems like we are saying "scripting is poorly defined,
+but we talk about it anyway."} - RPG}
 
 @section{Introduction}
 


### PR DESCRIPTION
Adds comments about rhetorical purpose in the abstract.

This commit has some minor fixes (like a better email address for me), but also has some comments about the rhetorical structure of the abstract.

The abstract suddenly pops in with a discussion of scripting, which isn't mentioned in the title, and isn't really carried through into an argument.  I'm inclined to think we're better off deferring discussion of CL for scripting to a separate paper.